### PR TITLE
Add Clippy calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ current calendars in this repository:
     - [Async Working Group](https://rust-lang.github.io/calendar/wg-async.ics)
     - [Types Team](https://rust-lang.github.io/calendar/types.ics)
     - [Macros Working Group](https://rust-lang.github.io/calendar/wg-macros.ics)
+  - [Dev Tools Team](https://rust-lang.github.io/calendar/dev-tools.ics)
+    - [Clippy Team](https://rust-lang.github.io/calendar/clippy.ics)
 
 You can copy these links and import them into your calendar application of choice.
 
@@ -47,7 +49,7 @@ repository to have an `archived-` prefix if we want.
 
 ## How do I add an event?
 First, select a TOML file that is relevant for your event - normally a team or working group's
-calendar will be appropriate. 
+calendar will be appropriate.
 
 Next, add a `events` table with the correct details for your event. You can copy the following
 snippet to get started:
@@ -74,7 +76,7 @@ calendar has been published. Just use the current UNIX time to basically guarant
 overlap with anything or anyone else.
 
 On Linux, you can get the current UNIX time with  `date +%s%N | cut -b1-13`, and on Windows, with
-PowerShell, `([DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds()`. Alternatively, you can copy the 
+PowerShell, `([DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds()`. Alternatively, you can copy the
 current UNIX time from a website like [currentmillis.com](https://currentmillis.com).
 
 See [*What is the schema for the calendars?*][schema] for a list of options you can set in an event.

--- a/all.toml
+++ b/all.toml
@@ -3,5 +3,6 @@ description = "Meetings for all of the teams in the Rust project"
 
 [meta]
 includes = [
-  "compiler.toml"
+  "compiler.toml",
+  "dev-tools.toml"
 ]

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,14 @@
+name = "Clippy Team"
+description = "Meetings for the Clippy team"
+
+[[events]]
+uid = "1704736291099"
+title = "Clippy meeting"
+description = "Biweekly team meeting of the Clippy team"
+location = "#clippy on Zulip (https://rust-lang.zulipchat.com/#narrow/stream/clippy)"
+last_modified_on = "2024-01-08T18:00:00.00Z"
+start = "2024-01-09T16:00:00.00Z"
+end = "2024-01-09T16:30:00.00Z"
+status = "confirmed"
+organizer = { name = "clippy", email = "clippy@rust-lang.org" }
+recurrence_rules = [ { frequency = "weekly", interval = 2 } ]

--- a/dev-tools.toml
+++ b/dev-tools.toml
@@ -1,0 +1,7 @@
+name = "Rust Dev Tools Team"
+description = "Meetings for the dev tools team and its sub-teams"
+
+[meta]
+includes = [
+  "clippy.toml"
+]


### PR DESCRIPTION
As Clippy is a sub-team of dev-tools, this adds 2 new toml files: `dev-tools.toml` and `clippy.toml`. The `dev-tools.toml` file just includes the `clippy.toml` file, as the dev-tools team currently doesn't have a recurring meeting.

---

Question: In my personal calendar I also have reminders for Clippy to do the Rust<->Clippy repo sync, the release, and beta-backports. Can/Shall those reminders also be included in the team calendars?