### PR TITLE
feat: Add testing-devex team calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ current calendars in this repository:
   - [Dev Tools Team](https://rust-lang.github.io/calendar/dev-tools.ics)
     - [Cargo Team](https://rust-lang.github.io/calendar/cargo.ics)] 
     - [Clippy Team](https://rust-lang.github.io/calendar/clippy.ics)
+    - [Testing DevEx Team](https://rust-lang.github.io/calendar/testing-devex.ics)
   - [Infrastructure Team](https://rust-lang.github.io/calendar/infrastructure.ics)
   - [Language Team](https://rust-lang.github.io/calendar/lang.ics)
   - [Library Team](https://rust-lang.github.io/calendar/libs.ics)

--- a/dev-tools.toml
+++ b/dev-tools.toml
@@ -4,5 +4,6 @@ description = "Meetings for the dev tools team and its sub-teams"
 [meta]
 includes = [
   "cargo.toml",
-  "clippy.toml"
+  "clippy.toml",
+  "testing-devex.toml"
 ]

--- a/testing-devex.toml
+++ b/testing-devex.toml
@@ -1,0 +1,19 @@
+name = "Testing DevEx Team"
+description = "Meetings for t-testing-devex"
+
+[meta]
+includes = [ "_timezones.toml" ]
+
+[[events]]
+uid = "1704841317021"
+title = "Testing DevEx Team Weekly Meeting"
+description = """The Testing DevEx team's weekly meeting
+Notes: https://hackmd.io/6VBcIw8QQ1WGDbnFiW84mA"""
+location = "https://meet.jit.si/t-testing-devex-team"
+created_on = "2024-01-09T23:02:04.29Z"
+last_modified_on = "2024-01-09T23:02:04.29Z"
+start = { date = "2024-01-16T17:00:00.00", timezone = "America/New_York" }
+end = { date = "2024-01-16T18:00:00.00", timezone = "America/New_York" }
+status = "confirmed"
+organizer = { name = "testing-devex", email = "tools@rust-lang.org" }
+recurrence_rules = [ { frequency = "weekly" } ]


### PR DESCRIPTION
This PR adds a calendar for the Testing DevEx team.

Note: Testing DevEx [does not have an email](https://github.com/rust-lang/team/blob/ae0fe5cb83bbb24c9533c6829f2ca11667e8ab2d/teams/testing-devex.toml), so I went ahead and [used one of `devtools`](https://github.com/rust-lang/team/blob/ae0fe5cb83bbb24c9533c6829f2ca11667e8ab2d/teams/devtools.toml#L42) as it is the parent team of `testing-devex`.

cc @rust-lang/testing-devex 