### PR TITLE
Fix "all" calendar

### DIFF
--- a/all.toml
+++ b/all.toml
@@ -6,6 +6,6 @@ includes = [
   "compiler.toml",
   "dev-tools.toml",
   "infrastructure.toml",
-  "language.toml",
-  "library.toml",
+  "lang.toml",
+  "libs.toml",
 ]


### PR DESCRIPTION
The calendar defined by `all.toml` does not build correctly because it requires two files that do not exist:

- `language.toml`
- `library.toml`

The corresponding files were instead named:

- `lang.toml`
- `libs.toml`

These names are better as they match the conventional names of the teams.  So let's fix the "all" calendar by updating it to refer to these files.