### PR TITLE
Remove obsolete meetings from T-lang calendar

### DIFF
--- a/lang.toml
+++ b/lang.toml
@@ -17,32 +17,6 @@ organizer = { name = "t-lang", email = "lang@rust-lang.org" }
 recurrence_rules = [ { frequency = "weekly" } ]
 
 [[events]]
-uid = "1704818466435"
-title = "Unsafe Code Guidelines Sync"
-description = """This is our weekly sync meeting where we check in on the current discussion area \
-to try and see how conversations are going. It is not meant to be used for discussing technical \
-matters, which should occur over Github or Zulip."""
-location = "#t-lang/wg-unsafe-code-guidelines on Zulip (https://rust-lang.zulipchat.com/#narrow/stream/136281-t-opsem)"
-last_modified_on = "2024-01-09T16:43:00.00Z"
-start = { date = "2024-01-11T11:15:00.00", timezone = "America/New_York" }
-end = { date = "2024-01-11T11:45:00.00", timezone = "America/New_York" }
-status = "confirmed"
-organizer = { name = "t-lang", email = "lang@rust-lang.org" }
-recurrence_rules = [ { frequency = "weekly" } ]
-
-[[events]]
-uid = "1704818677770"
-title = "FFI Unwind Project Group Sync"
-description = "Short sync meeting for the FFI-unwind project"
-location = "#project-ffi-unwind on Zulip (https://rust-lang.zulipchat.com/#narrow/stream/210922-project-ffi-unwind)"
-last_modified_on = "2024-01-09T16:45:00.00Z"
-start = { date = "2024-01-11T13:30:00.00", timezone = "America/New_York" }
-end = { date = "2024-01-11T14:00:00.00", timezone = "America/New_York" }
-status = "confirmed"
-organizer = { name = "t-lang", email = "lang@rust-lang.org" }
-recurrence_rules = [ { frequency = "weekly", interval = 2 } ]
-
-[[events]]
 uid = "1704818922931"
 title = "Lang Team Planning Meeting"
 description = """The planning meeting is the first meeting of each month. We do a “check-in” on \


### PR DESCRIPTION
We want the lang team calendar to represent only the meetings of the lang team itself rather than having it also include meetings of its subteams and chartered working groups and initiatives.

Currently, the calendar includes two non-T-lang meetings.  One is for T-opsem and the other is for project-ffi-unwind.  If these meetings were still alive, we would move them to separate calendars.  However, as far as we can tell, at the moment these meetings are not happening at the times and places scheduled here.

Consequently, let's simply remove these obsolete meetings from the lang team calendar, leaving only active T-lang meetings.