### PR TITLE
Mark subscribers as busy during T-lang, WG-async events

### DIFF
--- a/lang.toml
+++ b/lang.toml
@@ -9,10 +9,11 @@ uid = "1704818143227"
 title = "Lang Team Triage Meeting (Open)"
 description = """Language team's weekly triage meeting. Agenda will be posted before the meeting."""
 location = "https://meet.jit.si/ferris-rules"
-last_modified_on = "2024-01-09T16:39:00.00Z"
+last_modified_on = "2024-01-11T10:00:00.00Z"
 start = { date = "2024-01-10T08:00:00.00", timezone = "America/Los_Angeles" }
 end = { date = "2024-01-10T09:00:00.00", timezone = "America/Los_Angeles" }
 status = "confirmed"
+transparency = "opaque"
 organizer = { name = "t-lang", email = "lang@rust-lang.org" }
 recurrence_rules = [ { frequency = "weekly" } ]
 
@@ -23,10 +24,11 @@ description = """The planning meeting is the first meeting of each month. We do 
 the state of our various ongoing projects and we also plan the meetings for the remainder of the \
 month"""
 location = "https://meet.jit.si/ferris-rules"
-last_modified_on = "2024-01-09T16:50:00.00Z"
+last_modified_on = "2024-01-11T10:00:00.00Z"
 start = { date = "2024-01-03T13:00:00.00", timezone = "America/New_York" }
 end = { date = "2024-01-03T14:00:00.00", timezone = "America/New_York" }
 status = "confirmed"
+transparency = "opaque"
 organizer = { name = "t-lang", email = "lang@rust-lang.org" }
 recurrence_rules = [ { frequency = "monthly" } ]
 
@@ -35,9 +37,10 @@ uid = "1704819113100"
 title = "HOLD: Lang Team Design Meeting"
 description = "https://github.com/orgs/rust-lang/projects/31/views/10"
 location = "https://meet.jit.si/ferris-rules"
-last_modified_on = "2024-01-09T16:53:00.00Z"
+last_modified_on = "2024-01-11T10:00:00.00Z"
 start = { date = "2024-01-10T13:00:00.00", timezone = "America/New_York" }
 end = { date = "2024-01-10T14:00:00.00", timezone = "America/New_York" }
 status = "confirmed"
+transparency = "opaque"
 organizer = { name = "t-lang", email = "lang@rust-lang.org" }
 recurrence_rules = [ { frequency = "weekly" } ]

--- a/wg-async.toml
+++ b/wg-async.toml
@@ -6,10 +6,11 @@ uid = "1704471961833"
 title = "wg-async Weekly Meeting"
 description = "First Thursday of each month is sprint planning. On other weeks we do deep dives, reading clubs, and open discussion."
 location = "#wg-async on Zulip (https://rust-lang.zulipchat.com/#narrow/stream/187312-wg-async)"
-last_modified_on = "2024-01-05T16:27:00.00Z"
+last_modified_on = "2024-01-11T10:00:00.00Z"
 start = "2024-01-11T17:00:00.00Z"
 end = "2024-01-11T18:00:00.00Z"
 status = "confirmed"
+transparency = "opaque"
 organizer = { name = "wg-async", email = "compiler@rust-lang.org" }
 recurrence_rules = [ { frequency = "weekly" } ]
 
@@ -18,9 +19,10 @@ uid = "1704472122081"
 title = "wg-async Triage Meeting"
 description = "A biweekly sync to do triage, check up on issues that are assigned, assign new issues."
 location = "#wg-async on Zulip (https://rust-lang.zulipchat.com/#narrow/stream/187312-wg-async)"
-last_modified_on = "2024-01-05T16:28:00.00Z"
+last_modified_on = "2024-01-11T10:00:00.00Z"
 start = "2024-01-15T16:30:00.00Z"
 end = "2024-01-15T17:00:00.00Z"
 status = "confirmed"
+transparency = "opaque"
 organizer = { name = "wg-async", email = "compiler@rust-lang.org" }
 recurrence_rules = [ { frequency = "weekly", interval = 2 } ]


### PR DESCRIPTION
In many kinds of calendaring software, a person working in an organization will make his or her calendar available to others in such a way that those others can try to schedule around times when that person is busy.  To do this, calendaring software distinguishes between events that make the person busy and those that don't.

In the iCalendar standard, this is termed the "transparency" of the event.[^1]  An event which is "opaque" is one that consumes the attention of that individual.

The tooling here[^2] does not emit any "transparency" property in the output ICS file by default.  If we want this property emitted, we need to specify it.  Without it specified, calendaring software may use whatever its own default is.

The lang team meetings and those of WG-async are fully consuming. Let's mark those as opaque.

[^1]: https://datatracker.ietf.org/doc/html/rfc5545#section-3.8.2.7

[^2]: https://github.com/rust-lang/calendar-generation/