### PR TITLE
Add spec team calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ current calendars in this repository:
     - [Testing DevEx Team](https://rust-lang.github.io/calendar/testing-devex.ics)
   - [Infrastructure Team](https://rust-lang.github.io/calendar/infra.ics)
   - [Language Team](https://rust-lang.github.io/calendar/lang.ics)
+    - [Spec Team](https://rust-lang.github.io/calendar/spec.ics)
   - [Library Team](https://rust-lang.github.io/calendar/libs.ics)
   - [Embedded Devices Working Group](https://rust-lang.github.io/calendar/wg-embedded.ics)
 

--- a/all.toml
+++ b/all.toml
@@ -8,5 +8,6 @@ includes = [
   "infra.toml",
   "lang.toml",
   "libs.toml",
+  "spec.toml",
   "wg-embedded.toml",
 ]

--- a/spec.toml
+++ b/spec.toml
@@ -1,0 +1,18 @@
+name = "Rust Spec Team"
+description = "Meetings for the Rust language specification team."
+
+[meta]
+includes = [ "_timezones.toml" ]
+
+[[events]]
+uid = "b7af715576cc229aaf8c532ea89bb6ace1c91a65"
+title = "Rust Spec Team Meeting"
+description = """The Rust language specification team weekly meeting."""
+location = "https://meet.jit.si/rust-t-spec"
+last_modified_on = "2024-01-18T00:00:00.00Z"
+start = { date = "2024-01-18T11:00:00.00", timezone = "America/New_York" }
+end = { date = "2024-01-18T12:00:00.00", timezone = "America/New_York" }
+status = "confirmed"
+transparency = "opaque"
+organizer = { name = "t-spec", email = "lang@rust-lang.org" }
+recurrence_rules = [ { frequency = "weekly" } ]


### PR DESCRIPTION
The Rust language specification team (T-spec) currently meets once weekly on Thursdays.  Let's add a calendar for the team.