### PR TITLE
Add wg-binary-size meetings

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ current calendars in this repository:
   - [Language Team](https://rust-lang.github.io/calendar/lang.ics)
     - [Spec Team](https://rust-lang.github.io/calendar/spec.ics)
   - [Library Team](https://rust-lang.github.io/calendar/libs.ics)
-  - [Embedded Devices Working Group](https://rust-lang.github.io/calendar/wg-embedded.ics)
+  - Working Groups
+    - [Embedded Devices Working Group](https://rust-lang.github.io/calendar/wg-embedded.ics)
+    - [Binary Size Working Group](https://rust-lang.github.io/calendar/wg-binary-size.ics)
   - [Rust Releases](https://rust-lang.github.io/calendar/release.ics)
 
 You can copy these links and import them into your calendar application of choice.

--- a/all.toml
+++ b/all.toml
@@ -10,5 +10,6 @@ includes = [
   "lang.toml",
   "libs.toml",
   "spec.toml",
+  "wg-binary-size.toml",
   "wg-embedded.toml",
 ]

--- a/wg-binary-size.toml
+++ b/wg-binary-size.toml
@@ -1,0 +1,21 @@
+name = "Rust Binary Size WG"
+description = "Meetings for the Rust Binary Size Working Group"
+
+[[events]]
+uid = "1706055913163"
+title = "Rust Binary Size WG meeting"
+description = """\
+Public meeting of the binary size working group<br>
+<a href="https://rust-lang.zulipchat.com/#narrow/stream/405744-wg-binary-size/search/meeting">\
+Search for topics with \"meeting\" in the Zulip channel\
+</a><br>
+<a href="https://hackmd.io/BPiMVIcYQ_2svaAsOMktog">wg-binary-size info</a>
+"""
+location = "#wg-binary-size on Zulip (https://rust-lang.zulipchat.com/#narrow/stream/405744-wg-binary-size)"
+last_modified_on = "2024-01-23T0:00:00.00Z"
+# Timezone is UTC
+start = "2023-11-16T21:00:00.00Z"
+end = "2023-11-16T22:00:00.00Z"
+status = "confirmed"
+organizer = { name = "Rust Binary Size WG", email = "infrastructure@teams.rust-embedded.org" }
+recurrence_rules = [ { frequency = "weekly", interval = 2 } ]


### PR DESCRIPTION
For now, the timezone is UTC and so won't change with daylight savings. I included a link to the Zulip in the description as well, since putting it in the location makes it unclickable in Google Calendar (it tries to open Maps).

I confirmed it looks right when imported into my calendar.

@Kobzol @saethlin 