### PR TITLE
Fix Rust Releases calendar name

### DIFF
--- a/release.toml
+++ b/release.toml
@@ -1,4 +1,4 @@
-name = "Rust Releases Calendar"
+name = "Rust Releases"
 description = "New releases of Rust"
 
 [[events]]


### PR DESCRIPTION
Silly mistake in the name.

r? @davidtwco 