### PR TITLE
Base libs meetings on US timezone for DST

### DIFF
--- a/libs.toml
+++ b/libs.toml
@@ -10,8 +10,8 @@ title = "Libs Meeting"
 description = "Weekly t-libs meeting"
 location = "#t-libs/meetings on Zulip (https://rust-lang.zulipchat.com/#narrow/stream/259402-t-libs.2Fmeetings)"
 last_modified_on = "2024-02-21T16:03:10.56Z"
-start = { date = "2024-01-10T18:00:00.00", timezone = "Europe/Amsterdam" }
-end = { date = "2024-01-10T19:00:00.00", timezone = "Europe/Amsterdam" }
+start = { date = "2024-01-10T09:00:00.00", timezone = "US/Pacific" }
+end = { date = "2024-01-10T10:00:00.00", timezone = "US/Pacific" }
 status = "confirmed"
 organizer = { name = "t-libs", email = "libs@rust-lang.org" }
 recurrence_rules = [ { frequency = "weekly" } ]
@@ -22,8 +22,8 @@ title = "Libs API Meeting"
 description = "Weekly t-libs-api meeting"
 location = "#t-libs/meetings on Zulip (https://rust-lang.zulipchat.com/#narrow/stream/259402-t-libs.2Fmeetings)"
 last_modified_on = "2024-01-09T16:15:00.00Z"
-start = { date = "2024-01-09T17:00:00.00", timezone = "Europe/Amsterdam" }
-end = { date = "2024-01-09T18:00:00.00", timezone = "Europe/Amsterdam" }
+start = { date = "2024-01-09T08:00:00.00", timezone = "US/Pacific" }
+end = { date = "2024-01-09T09:00:00.00", timezone = "US/Pacific" }
 status = "confirmed"
 organizer = { name = "t-libs-api", email = "libs@rust-lang.org" }
 recurrence_rules = [ { frequency = "weekly" } ]
@@ -34,8 +34,8 @@ title = "Libs API Meeting - ACP Processing"
 description = "Biweekly t-libs-api meeting to process ACPs"
 location = "#t-libs/meetings on Zulip (https://rust-lang.zulipchat.com/#narrow/stream/259402-t-libs.2Fmeetings)"
 last_modified_on = "2024-01-09T16:19:00.00Z"
-start = { date = "2024-01-09T19:00:00.00", timezone = "Europe/Amsterdam" }
-end = { date = "2024-01-09T19:00:00.00", timezone = "Europe/Amsterdam" }
+start = { date = "2024-01-09T09:00:00.00", timezone = "US/Pacific" }
+end = { date = "2024-01-09T10:00:00.00", timezone = "US/Pacific" }
 status = "confirmed"
 organizer = { name = "t-libs-api", email = "libs@rust-lang.org" }
 recurrence_rules = [ { frequency = "weekly", interval = 2 } ]


### PR DESCRIPTION
This keeps meeting times aligned with other Rust teams during US/Europe DST mismatch.