### PR TITLE
Fix Types Team meetings

### DIFF
--- a/types.toml
+++ b/types.toml
@@ -1,14 +1,17 @@
 name = "Rust Types Team"
 description = "Meetings for the types team and its working groups"
 
+[meta]
+includes = [ "_timezones.toml" ]
+
 [[events]]
 uid = "1704470313292"
 title = "Types Team Meeting"
 description = "Weekly team meeting of the types team"
 location = "#t-types/meetings on Zulip (https://rust-lang.zulipchat.com/#narrow/stream/326132-t-types.2Fmeetings)"
-last_modified_on = "2024-01-05T15:49:00.00Z"
-start = "2024-01-08T15:00:00.00Z"
-end = "2024-01-08T16:00:00.00Z"
+last_modified_on = "2024-03-14T15:46:00.00Z"
+start = { date = "2024-01-08T10:00:00.00", timezone = "America/New_York" }
+end = { date = "2024-01-08T11:00:00.00", timezone = "America/New_York" }
 status = "confirmed"
 organizer = { name = "t-types", email = "types@rust-lang.org" }
 recurrence_rules = [ { frequency = "weekly" } ]
@@ -18,9 +21,9 @@ uid = "1704471680390"
 title = "Types Team: ITE (Impl Trait Everywhere) Triage"
 description = "Regular triage of the implementation of impl Trait-related features"
 location = "Jitsi (https://meet.jit.si/impl-trait-everywhere)"
-last_modified_on = "2024-01-08T15:35:00.00Z"
-start = "2024-01-11T21:00:00.00Z"
-end = "2024-01-11T21:30:00.00Z"
+last_modified_on = "2024-03-14T15:46:00.00Z"
+start = { date = "2024-01-11T16:00:00.00", timezone = "America/New_York" }
+end = { date = "2024-01-11T16:30:00.00", timezone = "America/New_York" }
 status = "confirmed"
 organizer = { name = "t-types", email = "types@rust-lang.org" }
 recurrence_rules = [ { frequency = "weekly" } ]

--- a/types.toml
+++ b/types.toml
@@ -24,15 +24,3 @@ end = "2024-01-11T21:30:00.00Z"
 status = "confirmed"
 organizer = { name = "t-types", email = "types@rust-lang.org" }
 recurrence_rules = [ { frequency = "weekly" } ]
-
-[[events]]
-uid = "1704471804390"
-title = "Types Team: Rotating Solver/Formality/Polonius Deep Dive"
-description = "Rotating deep dive into a types team project (https://hackmd.io/jjc-a_V4RWOYFTVpVeVsCA)"
-location = "Jitsi (https://meet.jit.si/p-equals-np)"
-last_modified_on = "2024-01-05T16:24:00.00Z"
-start = "2024-01-08T16:00:00.00Z"
-end = "2024-01-08T17:30:00.00Z"
-status = "confirmed"
-organizer = { name = "t-types", email = "types@rust-lang.org" }
-recurrence_rules = [ { frequency = "weekly" } ]


### PR DESCRIPTION
I'd like to fix the calendar of the @rust-lang/types.

The current commit just removes "Types Team: Rotating Solver/Formality/Polonius Deep Dive" as is not happening anymore.
I'm not sure about "Types Team: ITE (Impl Trait Everywhere) Triage".
And the "Types Team Meeting" is not happening either but not sure if we want to keep it.

Also ... what timezone should we use for these ones?. US timezone? if so ... can somebody point me to the right timing of the meetings in said timezone?.