### PR TITLE
Update libs & libs-api meeting times

### DIFF
--- a/libs.toml
+++ b/libs.toml
@@ -9,9 +9,9 @@ uid = "1704817069485"
 title = "Libs Meeting"
 description = "Weekly t-libs meeting"
 location = "#t-libs/meetings on Zulip (https://rust-lang.zulipchat.com/#narrow/stream/259402-t-libs.2Fmeetings)"
-last_modified_on = "2024-03-11T18:32:55.55Z"
+last_modified_on = "2024-08-21T14:48:43.33Z"
 start = { date = "2024-01-10T09:00:00.00", timezone = "US/Pacific" }
-end = { date = "2024-01-10T10:00:00.00", timezone = "US/Pacific" }
+end = { date = "2024-01-10T09:30:00.00", timezone = "US/Pacific" }
 status = "confirmed"
 organizer = { name = "t-libs", email = "libs@rust-lang.org" }
 recurrence_rules = [ { frequency = "weekly" } ]
@@ -31,11 +31,11 @@ recurrence_rules = [ { frequency = "weekly" } ]
 [[events]]
 uid = "1704817148560"
 title = "Libs API Meeting - ACP Processing"
-description = "Biweekly t-libs-api meeting to process ACPs"
+description = "Weekly t-libs-api meeting to process ACPs"
 location = "#t-libs/meetings on Zulip (https://rust-lang.zulipchat.com/#narrow/stream/259402-t-libs.2Fmeetings)"
-last_modified_on = "2024-03-11T18:32:55.55Z"
-start = { date = "2024-01-09T09:00:00.00", timezone = "US/Pacific" }
-end = { date = "2024-01-09T10:00:00.00", timezone = "US/Pacific" }
+last_modified_on = "2024-08-21T14:48:43.33Z"
+start = { date = "2024-01-09T10:00:00.00", timezone = "US/Pacific" }
+end = { date = "2024-01-09T12:00:00.00", timezone = "US/Pacific" }
 status = "confirmed"
 organizer = { name = "t-libs-api", email = "libs@rust-lang.org" }
-recurrence_rules = [ { frequency = "weekly", interval = 2 } ]
+recurrence_rules = [ { frequency = "weekly" } ]


### PR DESCRIPTION
libs-api: Instead of a bi-weekly 1 hour meeting for processing ACPs, use a weekly 2 hour meeting.

libs: Change meeting length to 30 minutes instead of 1 hour to avoid conflicting with the lang design meeting.