### PR TITLE
End broken lang planning meeting event

### DIFF
--- a/lang.toml
+++ b/lang.toml
@@ -20,19 +20,6 @@ organizer = { name = "t-lang", email = "lang@rust-lang.org" }
 recurrence_rules = [ { frequency = "weekly" } ]
 
 [[events]]
-uid = "9fa5f574898e6a2417d9ac9b20b5294507c15e2a"
-title = "Lang Team Planning Meeting"
-description = "In this meeting, we plan the design meetings for the month."
-location = "https://meet.jit.si/ferris-rules"
-last_modified_on = "2024-02-29T00:00:00.00Z"
-start = { date = "2024-03-06T12:30:00.00", timezone = "America/New_York" }
-end = { date = "2024-03-06T14:00:00.00", timezone = "America/New_York" }
-status = "confirmed"
-transparency = "opaque"
-organizer = { name = "t-lang", email = "lang@rust-lang.org" }
-recurrence_rules = [ { frequency = "monthly" } ]
-
-[[events]]
 uid = "2be23d34f40821a2793cf8bf2db5b1bcbfe620f3"
 title = "Lang Team Design Meeting"
 description = "https://github.com/orgs/rust-lang/projects/31/views/10"
@@ -46,6 +33,19 @@ organizer = { name = "t-lang", email = "lang@rust-lang.org" }
 recurrence_rules = [ { frequency = "weekly" } ]
 
 # Past recurring events
+
+[[events]]
+uid = "9fa5f574898e6a2417d9ac9b20b5294507c15e2a"
+title = "Lang Team Planning Meeting"
+description = "In this meeting, we plan the design meetings for the month."
+location = "https://meet.jit.si/ferris-rules"
+last_modified_on = "2024-10-22T00:00:00.00Z"
+start = { date = "2024-03-06T12:30:00.00", timezone = "America/New_York" }
+end = { date = "2024-03-06T14:00:00.00", timezone = "America/New_York" }
+status = "confirmed"
+transparency = "opaque"
+organizer = { name = "t-lang", email = "lang@rust-lang.org" }
+recurrence_rules = [ { frequency = "monthly", until = "2024-03-07T00:00:00.00Z" } ]
 
 [[events]]
 uid = "1704818922931"


### PR DESCRIPTION
We have a lang planning meeting scheduled for the first Wednesday of every month.  This was set up as a monthly-recurring event starting on 2024-03-06, which was a Wednesday.

However, what that actually encodes is a meeting every month on the 6th.  That's not what we want and has been confusing people, so let's retroactively end that recurrence.

We don't need any replacement here, as we actually just use our design meeting slot for this, and lately we've been mixing it up a bit and not always doing these on the first Wednesday of the month.

cc @davidtwco