### PR TITLE
Update Types Team calendar

### DIFF
--- a/types.toml
+++ b/types.toml
@@ -14,7 +14,7 @@ start = { date = "2024-01-08T10:00:00.00", timezone = "America/New_York" }
 end = { date = "2024-01-08T11:00:00.00", timezone = "America/New_York" }
 status = "confirmed"
 organizer = { name = "t-types", email = "types@rust-lang.org" }
-recurrence_rules = [ { frequency = "weekly" } ]
+recurrence_rules = [ { frequency = "weekly", until = "2024-11-13T00:00:00.00Z" } ]
 
 [[events]]
 uid = "1704471680390"
@@ -26,14 +26,14 @@ start = { date = "2024-01-11T16:00:00.00", timezone = "America/New_York" }
 end = { date = "2024-01-11T16:30:00.00", timezone = "America/New_York" }
 status = "confirmed"
 organizer = { name = "t-types", email = "types@rust-lang.org" }
-recurrence_rules = [ { frequency = "weekly" } ]
+recurrence_rules = [ { frequency = "weekly", until = "2024-11-13T00:00:00.00Z" } ]
 
 [[events]]
 uid = "5183091736401"
 title = "Types Team High Bandwidth Discussions"
 description = "Regular meeting discussing items from the Types Team roadmap"
 location = "Jitsi (https://meet.jit.si/curry-howard-ftw)"
-last_modified_on = "2024-04-24T10:39:00.00Z"
+last_modified_on = "2024-11-30T10:39:00.00Z"
 start = { date = "2024-04-30T10:30:00.00", timezone = "America/New_York" }
 end = { date = "2024-04-30T12:00:00.00", timezone = "America/New_York" }
 status = "confirmed"


### PR DESCRIPTION
Removed the weekly occurrence from two Types team meetings that are not taking place anymore, this should be enough to remove them from our calenders.

(agreed this change with @lcnr )

r? @tgross35 

thanks!