### PR TITLE
Disable wg-debugging triage meeting

### DIFF
--- a/wg-debugging.toml
+++ b/wg-debugging.toml
@@ -11,5 +11,4 @@ start = "2024-01-15T15:00:00.00Z"
 end = "2024-01-15T16:00:00.00Z"
 status = "confirmed"
 organizer = { name = "wg-debugging", email = "compiler@rust-lang.org" }
-recurrence_rules = [ { frequency = "monthly" } ]
-
+recurrence_rules = [ { frequency = "weekly", until = "2024-12-04T12:00:00.00Z" } ]


### PR DESCRIPTION
As discussed [on Zulip](https://rust-lang.zulipchat.com/#narrow/channel/317568-t-compiler.2Fwg-debugging/topic/Calendar.20for.20triage.20meeting.20update).

cc: @davidtwco 