### PR TITLE
Fix last modified_on for old events that were not updated

### DIFF
--- a/types.toml
+++ b/types.toml
@@ -9,7 +9,7 @@ uid = "1704470313292"
 title = "Types Team Meeting"
 description = "Weekly team meeting of the types team"
 location = "#t-types/meetings on Zulip (https://rust-lang.zulipchat.com/#narrow/stream/326132-t-types.2Fmeetings)"
-last_modified_on = "2024-03-14T15:46:00.00Z"
+last_modified_on = "2024-12-17T10:00:00.00Z"
 start = { date = "2024-01-08T10:00:00.00", timezone = "America/New_York" }
 end = { date = "2024-01-08T11:00:00.00", timezone = "America/New_York" }
 status = "confirmed"
@@ -21,7 +21,7 @@ uid = "1704471680390"
 title = "Types Team: ITE (Impl Trait Everywhere) Triage"
 description = "Regular triage of the implementation of impl Trait-related features"
 location = "Jitsi (https://meet.jit.si/impl-trait-everywhere)"
-last_modified_on = "2024-03-14T15:46:00.00Z"
+last_modified_on = "2024-12-17T10:00:00.00Z"
 start = { date = "2024-01-11T16:00:00.00", timezone = "America/New_York" }
 end = { date = "2024-01-11T16:30:00.00", timezone = "America/New_York" }
 status = "confirmed"


### PR DESCRIPTION
In this commit https://github.com/rust-lang/calendar/commit/4afc4d5fa9ecff59b8711ce1f9baf9ad0f0458ba we did not update last_modified_on