### PR TITLE
Type team office hours start in 2025

### DIFF
--- a/types.toml
+++ b/types.toml
@@ -45,9 +45,9 @@ uid = "09038f9ca2b7d003a12249d8d20a8b5971d4bf71"
 title = "Types Team Office Hours"
 description = "Weekly team office hours"
 location = "Jitsi (https://meet.jit.si/curry-howard-ftw)"
-last_modified_on = "2024-12-17T10:00:00.00Z"
-start = { date = "2024-12-17T10:30:00.00", timezone = "America/New_York" }
-end = { date = "2024-12-17T12:00:00.00", timezone = "America/New_York" }
+last_modified_on = "2024-12-20T10:00:00.00Z"
+start = { date = "2025-01-07T10:30:00.00", timezone = "America/New_York" }
+end = { date = "2025-01-07T12:00:00.00", timezone = "America/New_York" }
 status = "confirmed"
 organizer = { name = "t-types", email = "types@rust-lang.org" }
 recurrence_rules = [ { frequency = "weekly" } ]


### PR DESCRIPTION
This makes the meeting start the first Tuesday of 2025.

One important question is, are we using jitsi or zulip?.

r? @rust-lang/types 