### PR TITLE
Separate release team calendar and Rust release calendars

### DIFF
--- a/all.toml
+++ b/all.toml
@@ -13,4 +13,5 @@ includes = [
   "spec.toml",
   "wg-binary-size.toml",
   "wg-embedded.toml",
+  "release-team.toml",
 ]

--- a/release-team.toml
+++ b/release-team.toml
@@ -1,0 +1,14 @@
+name = "Rust Release Team"
+description = "Release team activities"
+
+[[events]]
+uid = "f788e32dd599c6c8f9cbf8ab0b323270676f82dd"
+title = "Release Team Meeting"
+last_modified_on = "2025-02-10T00:00:00.00Z"
+organizer = { name = "t-release", email = "release@rust-lang.org" }
+description = "Weekly team meeting"
+location = "#t-release on Zulip (https://rust-lang.zulipchat.com/#narrow/channel/241545-t-release)"
+start = { date = "2025-01-31T12:30:00.00", timezone = "America/New_York" }
+end = { date = "2025-01-31T13:00:00.00", timezone = "America/New_York" }
+status = "confirmed"
+recurrence_rules = [ { frequency = "weekly" } ]

--- a/release.toml
+++ b/release.toml
@@ -9,6 +9,7 @@ start = "2024-02-08"
 organizer = { name = "t-infra", email = "infra@rust-lang.org" }
 recurrence_rules = [ { frequency = "weekly", interval = 6 } ]
 
+# Deleted event, this belongs in a separate calendar file (release-team.toml).
 [[events]]
 uid = "42985c1ccc9931952a2eecb21f96ec06ecea5492"
 title = "Release Team Meeting"
@@ -19,4 +20,4 @@ location = "#t-release on Zulip (https://rust-lang.zulipchat.com/#narrow/channel
 start = { date = "2025-01-31T12:30:00.00", timezone = "America/New_York" }
 end = { date = "2025-01-31T13:00:00.00", timezone = "America/New_York" }
 status = "confirmed"
-recurrence_rules = [ { frequency = "weekly" } ]
+recurrence_rules = [ { frequency = "weekly", until = "2025-02-19T13:50:00.00Z" } ]


### PR DESCRIPTION
I opted for creating a new calendar for the release team rather than re-purposing release.toml, since I think that makes more sense than asking any users to shift over to the new subscription source.

r? @spastorino 