### PR TITLE
Upgrade Ubuntu image for CI

### DIFF
--- a/.github/workflows/calendar.yml
+++ b/.github/workflows/calendar.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   generate:
     name: generate
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4.1.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ name: check tools
 jobs:
   test:
     name: test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4.1.1
       - uses: dtolnay/rust-toolchain@stable
@@ -20,7 +20,7 @@ jobs:
 
   fmt:
     name: rustfmt
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4.1.1
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/mr.yml
+++ b/.github/workflows/mr.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   generate:
     name: generate
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4.1.1


### PR DESCRIPTION
Ubuntu 20.04 was deprecated a few days ago, see
https://github.com/actions/runner-images/issues/11101

I had a failure on the last patch I merged
https://github.com/rust-lang/calendar/actions/runs/14627688168

r? @Kobzol for an opinion: should be fairly straightforward, right?

Thanks