### PR TITLE
Remove rylev from performance triage rotation

### DIFF
--- a/wg-performance.toml
+++ b/wg-performance.toml
@@ -2,18 +2,6 @@ name = "Performance Working Group"
 description = "Meetings for the compiler performance working group"
 
 [[events]]
-uid = "1704470086455"
-title = "Performance Triage Deadline"
-description = "Approximate time when performance triage should happen by"
-location = "#t-compiler/performance on Zulip (https://rust-lang.zulipchat.com/#narrow/stream/247081-t-compiler.2Fperformance)"
-last_modified_on = "2024-12-29T15:56:00.00Z"
-start = "2024-01-09T16:00:00.00Z"
-end = "2024-01-09T17:00:00.00Z"
-status = "confirmed"
-organizer = { name = "wg-performance", email = "compiler@rust-lang.org" }
-recurrence_rules = [ { frequency = "weekly", until = "2024-12-20T00:00:00.00Z" } ]
-
-[[events]]
 uid = "1704731526331"
 title = "simulacrum: performance triage"
 description = """simulacrum's turn to do performance triage
@@ -22,11 +10,58 @@ description = """simulacrum's turn to do performance triage
 2. Do the triage (see https://github.com/rust-lang/rustc-perf/tree/master/triage#readme)
 3. Post PRs to rust-lang/rustc-perf and rust-lang/this-week-in-rust"""
 location = "#t-compiler/performance on Zulip (https://rust-lang.zulipchat.com/#narrow/stream/247081-t-compiler.2Fperformance)"
-last_modified_on = "2025-05-05T18:00:00.00Z"
-start = "2025-05-05"
+last_modified_on = "2025-07-28T10:00:00.00Z"
+start = "2025-07-28"
 status = "confirmed"
 organizer = { name = "wg-performance", email = "compiler@rust-lang.org" }
-recurrence_rules = [ { frequency = "weekly", interval = 4 } ]
+recurrence_rules = [ { frequency = "weekly", interval = 3 } ]
+
+[[events]]
+uid = "1746440207144"
+title = "panstromek: performance triage"
+description = """panstromek's turn to do performance triage
+
+1. Open a date-tagged topic in zulip t-compiler/performance
+2. Do the triage (see https://github.com/rust-lang/rustc-perf/tree/master/triage#readme)
+3. Post PRs to rust-lang/rustc-perf and rust-lang/this-week-in-rust"""
+location = "#t-compiler/performance on Zulip (https://rust-lang.zulipchat.com/#narrow/stream/247081-t-compiler.2Fperformance)"
+last_modified_on = "2025-07-28T10:00:00.00Z"
+start = "2025-08-04"
+status = "confirmed"
+organizer = { name = "wg-performance", email = "compiler@rust-lang.org" }
+recurrence_rules = [ { frequency = "weekly", interval = 3 } ]
+
+[[events]]
+uid = "1704796350522"
+title = "kobzol: performance triage"
+description = """kobzol's turn to do performance triage
+
+1. Open a date-tagged topic in zulip t-compiler/performance
+2. Do the triage (see https://github.com/rust-lang/rustc-perf/tree/master/triage#readme)
+3. Post PRs to rust-lang/rustc-perf and rust-lang/this-week-in-rust"""
+location = "#t-compiler/performance on Zulip (https://rust-lang.zulipchat.com/#narrow/stream/247081-t-compiler.2Fperformance)"
+last_modified_on = "2025-07-28T10:00:00.00Z"
+start = "2025-08-11"
+status = "confirmed"
+organizer = { name = "wg-performance", email = "compiler@rust-lang.org" }
+recurrence_rules = [ { frequency = "weekly", interval = 3 } ]
+
+# Inactive events and triage members
+
+[[events]]
+uid = "1704733549327"
+title = "rylev: performance triage"
+description = """rylev's turn to do performance triage
+
+1. Open a date-tagged topic in zulip t-compiler/performance
+2. Do the triage (see https://github.com/rust-lang/rustc-perf/tree/master/triage#readme)
+3. Post PRs to rust-lang/rustc-perf and rust-lang/this-week-in-rust"""
+location = "#t-compiler/performance on Zulip (https://rust-lang.zulipchat.com/#narrow/stream/247081-t-compiler.2Fperformance)"
+last_modified_on = "2025-07-28T10:00:00.00Z"
+start = "2025-05-26"
+status = "confirmed"
+organizer = { name = "wg-performance", email = "compiler@rust-lang.org" }
+recurrence_rules = [ { frequency = "weekly", interval = 4, until = "2025-07-28T00:00:00.00Z" } ]
 
 [[events]]
 uid = "1704733471492"
@@ -44,46 +79,13 @@ organizer = { name = "wg-performance", email = "compiler@rust-lang.org" }
 recurrence_rules = [ { frequency = "weekly", interval = 4, until = "2024-12-30T00:00:00.00Z" } ]
 
 [[events]]
-uid = "1746440207144"
-title = "panstromek: performance triage"
-description = """panstromek's turn to do performance triage
-
-1. Open a date-tagged topic in zulip t-compiler/performance
-2. Do the triage (see https://github.com/rust-lang/rustc-perf/tree/master/triage#readme)
-3. Post PRs to rust-lang/rustc-perf and rust-lang/this-week-in-rust"""
+uid = "1704470086455"
+title = "Performance Triage Deadline"
+description = "Approximate time when performance triage should happen by"
 location = "#t-compiler/performance on Zulip (https://rust-lang.zulipchat.com/#narrow/stream/247081-t-compiler.2Fperformance)"
-last_modified_on = "2025-05-05T18:00:00.00Z"
-start = "2025-05-12"
+last_modified_on = "2024-12-29T15:56:00.00Z"
+start = "2024-01-09T16:00:00.00Z"
+end = "2024-01-09T17:00:00.00Z"
 status = "confirmed"
 organizer = { name = "wg-performance", email = "compiler@rust-lang.org" }
-recurrence_rules = [ { frequency = "weekly", interval = 4 } ]
-
-[[events]]
-uid = "1704796350522"
-title = "kobzol: performance triage"
-description = """kobzol's turn to do performance triage
-
-1. Open a date-tagged topic in zulip t-compiler/performance
-2. Do the triage (see https://github.com/rust-lang/rustc-perf/tree/master/triage#readme)
-3. Post PRs to rust-lang/rustc-perf and rust-lang/this-week-in-rust"""
-location = "#t-compiler/performance on Zulip (https://rust-lang.zulipchat.com/#narrow/stream/247081-t-compiler.2Fperformance)"
-last_modified_on = "2025-05-05T18:00:00.00Z"
-start = "2025-05-19"
-status = "confirmed"
-organizer = { name = "wg-performance", email = "compiler@rust-lang.org" }
-recurrence_rules = [ { frequency = "weekly", interval = 4 } ]
-
-[[events]]
-uid = "1704733549327"
-title = "rylev: performance triage"
-description = """rylev's turn to do performance triage
-
-1. Open a date-tagged topic in zulip t-compiler/performance
-2. Do the triage (see https://github.com/rust-lang/rustc-perf/tree/master/triage#readme)
-3. Post PRs to rust-lang/rustc-perf and rust-lang/this-week-in-rust"""
-location = "#t-compiler/performance on Zulip (https://rust-lang.zulipchat.com/#narrow/stream/247081-t-compiler.2Fperformance)"
-last_modified_on = "2025-05-05T18:00:00.00Z"
-start = "2025-05-26"
-status = "confirmed"
-organizer = { name = "wg-performance", email = "compiler@rust-lang.org" }
-recurrence_rules = [ { frequency = "weekly", interval = 4 } ]
+recurrence_rules = [ { frequency = "weekly", until = "2024-12-20T00:00:00.00Z" } ]


### PR DESCRIPTION
Switched the rotation back to three weeks, and reset it so that it starts from this week.

CC @Mark-Simulacrum