### PR TITLE
Add missing timezone definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ If the event isn't recurring, then you don't need to remove it, it'll just stay 
 in the past. If the event is incorrect, you can always update it, see
 [*How do I update an event?*][update].
 
-If the event is recurring, add `until` to the recurrence rules to stop the event atthe current date,
+If the event is recurring, add `until` to the recurrence rules to stop the event at the current date,
 preventing future recurrences. For example, this rule..
 
 ```toml

--- a/_timezones.toml
+++ b/_timezones.toml
@@ -4,6 +4,8 @@ description = "Include this file in a calendar if you need one of these timezone
 # You can check what Google Calendars outputs in an ICS file when a calendar has
 # an event in a given timezone to check what to put here. Look for `BEGIN:VTIMEZONE`.
 
+# Validation on https://icalendar.org/validator.html
+
 [[timezones]]
 name = "America/Los_Angeles"
 
@@ -36,6 +38,40 @@ name = "EDT"
 start = "1970-03-08T02:00:00.00"
 from = "-0500"
 to = "-0400"
+rule = { frequency = "yearly", by_month = [3], by_day = [ { day = "sunday", num = 2 } ] }
+
+[[timezones]]
+name = "America/Chicago"
+
+[timezones.standard]
+name = "CDT"
+start = "1970-11-01T02:00:00.00"
+rule = { frequency = "yearly", by_month = [11], by_day = [ { day = "sunday", num = 1 } ] }
+from = "-0500"
+to = "-0600"
+
+[timezones.daylight]
+name = "CST"
+start = "1970-03-08T02:00:00.00"
+from = "-0600"
+to = "-0500"
+rule = { frequency = "yearly", by_month = [3], by_day = [ { day = "sunday", num = 2 } ] }
+
+[[timezones]]
+name = "US/Pacific"
+
+[timezones.standard]
+name = "PST"
+start = "1970-11-01T02:00:00.00"
+from = "-0700"
+to = "-0800"
+rule = { frequency = "yearly", by_month = [11], by_day = [ { day = "sunday", num = 1 } ] }
+
+[timezones.daylight]
+name = "PDT"
+start = "1970-03-08T02:00:00.00"
+from = "-0800"
+to = "-0700"
 rule = { frequency = "yearly", by_month = [3], by_day = [ { day = "sunday", num = 2 } ] }
 
 [[timezones]]


### PR DESCRIPTION
While looking at other things, I discovered that the .ics we generate doesn't pass a strict validation, some timezones definitions were missing. Unsure in practice what this means.
https://icalendar.org/validator.html

This patch should fix the validation, though I am not 100% sure of the definition i have added. I've let this [page](https://www.timeanddate.com/time/zone/usa/chicago) and this [page](https://www.timeanddate.com/time/zones/pt) guide me.

@davidtwco do you remember how you pulled out the timezone information?

r?

thanks