### PR TITLE
Add periodic events to the Leadership Council calendar

### DIFF
--- a/council.toml
+++ b/council.toml
@@ -15,3 +15,15 @@ end = { date = "2024-01-19T12:30:00.00", timezone = "America/New_York" }
 status = "confirmed"
 organizer = { name = "Rust Leadership Council", email = "council@rust-lang.org" }
 recurrence_rules = [ { frequency = "weekly", interval = 2 } ]
+
+[[events]]
+uid = "abeb70d949c5d5bfa94372a89a8a0574a13980d6"
+title = "Leadership Council Update blog post"
+description = "Write and publish the regular Leadership Council Update blog post on the Inside Rust blog"
+location = "Inside Rust blog"
+last_modified_on = "2026-07-23T08:00:00.00Z"
+start = "2026-09-01T13:00:00.00Z"
+end = "2026-09-01T14:00:00.00Z"
+status = "confirmed"
+organizer = { name = "Rust Leadership Council", email = "council@rust-lang.org" }
+recurrence_rules = [ { frequency = "monthly", interval = 3 } ]

--- a/council.toml
+++ b/council.toml
@@ -27,3 +27,15 @@ end = "2026-09-01T14:00:00.00Z"
 status = "confirmed"
 organizer = { name = "Rust Leadership Council", email = "council@rust-lang.org" }
 recurrence_rules = [ { frequency = "monthly", interval = 3 } ]
+
+[[events]]
+uid = "d5f4fa824fa28d029d2c999ddf8fafa50c993b0e"
+title = "Leadership Council Performance survey"
+description = "Write and publish the regular Leadership Council Performance survey amongst Rust Project members. Once the survey is finished, analyze the results and write a blog post."
+location = "Rust Project Zulip"
+last_modified_on = "2026-07-23T08:00:00.00Z"
+start = "2027-06-01T13:00:00.00Z"
+end = "2027-06-01T14:00:00.00Z"
+status = "confirmed"
+organizer = { name = "Rust Leadership Council", email = "council@rust-lang.org" }
+recurrence_rules = [ { frequency = "yearly", interval = 1 } ]

--- a/council.toml
+++ b/council.toml
@@ -51,3 +51,15 @@ end = "2026-09-01T15:00:00.00Z"
 status = "confirmed"
 organizer = { name = "Rust Leadership Council", email = "council@rust-lang.org" }
 recurrence_rules = [ { frequency = "monthly", interval = 6 } ]
+
+[[events]]
+uid = "d7a55f4e92fe7a3ccb3c706a9ee342a0695481c8"
+title = "Project Director election"
+description = "Facilitate the annual Project Director elections. Coordinate with Program managers to gather nominations and then perform the election itself."
+location = "Rust Project Zulip"
+last_modified_on = "2026-07-23T08:00:00.00Z"
+start = "2026-08-24T14:00:00.00Z"
+end = "2026-08-24T15:00:00.00Z"
+status = "confirmed"
+organizer = { name = "Rust Leadership Council", email = "council@rust-lang.org" }
+recurrence_rules = [ { frequency = "yearly", interval = 1 } ]

--- a/council.toml
+++ b/council.toml
@@ -39,3 +39,15 @@ end = "2027-06-01T14:00:00.00Z"
 status = "confirmed"
 organizer = { name = "Rust Leadership Council", email = "council@rust-lang.org" }
 recurrence_rules = [ { frequency = "yearly", interval = 1 } ]
+
+[[events]]
+uid = "0b74e6b3054d7bcb52161047d0b25d00d483b6bb"
+title = "Leadership Council member rotation"
+description = "Half of the Council rotates out. Coordinate with Program managers to organize elections. Once they are done, welcome the new members."
+location = "Rust Project Zulip"
+last_modified_on = "2026-07-23T08:00:00.00Z"
+start = "2026-09-01T14:00:00.00Z"
+end = "2026-09-01T15:00:00.00Z"
+status = "confirmed"
+organizer = { name = "Rust Leadership Council", email = "council@rust-lang.org" }
+recurrence_rules = [ { frequency = "monthly", interval = 6 } ]


### PR DESCRIPTION
I added reminders about PD elections, Council member rotation, the annual Council performance survey and the regular Council update blog posts.

I didn't include the Rust Foundation board meetings, because we get notified of those regularly by PDs and Bec, and usually it's not something that requires action from the Council specifically (without reading the board notes we can't really have anything to act upon anyway).
