### PR TITLE
Remove libs meeting; libs-api meeting is the libs meeting now

### DIFF
--- a/libs.toml
+++ b/libs.toml
@@ -5,25 +5,13 @@ description = "Meetings for the library team and its working groups"
 includes = [ "_timezones.toml" ]
 
 [[events]]
-uid = "1704817069485"
-title = "Libs Meeting"
-description = "Weekly t-libs meeting"
-location = "#t-libs/meetings on Zulip (https://rust-lang.zulipchat.com/#narrow/stream/259402-t-libs.2Fmeetings)"
-last_modified_on = "2024-08-21T14:48:43.33Z"
-start = { date = "2024-01-10T09:00:00.00", timezone = "US/Pacific" }
-end = { date = "2024-01-10T09:30:00.00", timezone = "US/Pacific" }
-status = "confirmed"
-organizer = { name = "t-libs", email = "libs@rust-lang.org" }
-recurrence_rules = [ { frequency = "weekly" } ]
-
-[[events]]
 uid = "1704816854336"
-title = "Libs API Meeting"
-description = "Weekly t-libs-api meeting for nominated items and ACPs. We can finish early if the discussion has been too draining."
+title = "Libs Meeting"
+description = "Weekly t-libs meeting for nominated items and ACPs. We can finish early if the discussion has been too draining."
 location = "#t-libs/meetings on Zulip (https://rust-lang.zulipchat.com/#narrow/stream/259402-t-libs.2Fmeetings)"
-last_modified_on = "2026-03-31T18:32:55.55Z"
+last_modified_on = "2026-08-05T22:07:03.47Z"
 start = { date = "2024-01-09T08:00:00.00", timezone = "US/Pacific" }
 end = { date = "2024-01-09T11:00:00.00", timezone = "US/Pacific" }
 status = "confirmed"
-organizer = { name = "t-libs-api", email = "libs@rust-lang.org" }
+organizer = { name = "t-libs", email = "libs@rust-lang.org" }
 recurrence_rules = [ { frequency = "weekly" } ]


### PR DESCRIPTION
cc @nia-e @Amanieu 

With [RFC 3984](https://github.com/rust-lang/rfcs/pull/3984), the libs and libs-api teams are merged. Since FCP will end before the next meeting, and because the old libs meeting had few notable items for the past few weeks, it seems most appropriate to just incorporate it into the old libs-api meeting for now.

Eventually, the meeting will probably be reworked based upon the new libs-fcp team, once that's decided, but this is mostly just the temporary solution in the meantime.