### PR TITLE
Make the spec meeting monthly and async

### DIFF
--- a/spec.toml
+++ b/spec.toml
@@ -6,13 +6,13 @@ includes = [ "_timezones.toml" ]
 
 [[events]]
 uid = "b7af715576cc229aaf8c532ea89bb6ace1c91a65"
-title = "Rust Spec Team Meeting"
-description = """The Rust language specification team meeting."""
+title = "Rust Spec Team Meeting (async)"
+description = """The Rust language specification team meeting. Async, updates in #t-spec."""
 location = "https://meet.jit.si/rust-t-spec"
-last_modified_on = "2025-10-31T00:00:00.00Z"
-start = { date = "2025-10-30T11:00:00.00", timezone = "America/New_York" }
-end = { date = "2025-10-30T11:30:00.00", timezone = "America/New_York" }
+last_modified_on = "2026-08-11T10:00:00.00Z"
+start = { date = "2026-08-20T11:00:00.00", timezone = "America/New_York" }
+end = { date = "2026-08-20T11:30:00.00", timezone = "America/New_York" }
 status = "confirmed"
 transparency = "opaque"
 organizer = { name = "t-spec", email = "lang@rust-lang.org" }
-recurrence_rules = [ { frequency = "weekly", interval = 2 } ]
+recurrence_rules = [ { frequency = "monthly", interval = 1 } ]


### PR DESCRIPTION
We've been running them async for the last few months.

The new monthly frequency was discussed here:

https://rust-lang.zulipchat.com/#narrow/channel/399173-t-spec/topic/Meeting.202026-08-06.20.28async.29/near/615019964